### PR TITLE
fixed useDraggable returning x for y

### DIFF
--- a/packages/core/src/useDraggable/index.ts
+++ b/packages/core/src/useDraggable/index.ts
@@ -134,7 +134,7 @@ export function useDraggable(
 
   return {
     x: () => position.value.x,
-    y: () => position.value.x,
+    y: () => position.value.y,
     position,
     isDragging: createMemo(() => !!pressedDelta.value),
     style: createMemo(() => ({ left: `${position.value.x}px`, top: `${position.value.y}px` }))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The `useDraggable` function returned the `x` value when using the `y()` accessor, this fixes that.

As a sidenote, it doesn't look like there's a way to set the `x` and `y` positions manually, should I open another PR for that or add it to this?

<!-- ### Additional context -->

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

copilot:summary

copilot:walkthrough
