### PR TITLE
fix useWakeLock demo

### DIFF
--- a/packages/core/src/useWakeLock/demo.tsx
+++ b/packages/core/src/useWakeLock/demo.tsx
@@ -4,8 +4,8 @@ import { useWakeLock } from 'solidjs-use'
 
 const Demo = () => {
   const { isActive, request, release, isSupported } = useWakeLock()
-  const text = createMemo(() => (isActive() ? 'OFF' : 'ON'))
-  const onClick = () => (isActive() ? request('screen') : release())
+  const text = createMemo(() => (isActive() ? 'Release' : 'Request'))
+  const onClick = () => (isActive() ? release() : request('screen'))
   return (
     <>
       <div>


### PR DESCRIPTION
Thank you for this nice collection of utilities for Solid. Love to see the ecosystem grow :heart: 

# Current state

The [demo of useWakeLock](https://solidjs-use.github.io/solidjs-use/core/useWakeLock) doesn't work, because the usage of `request("screen")` and `release` are reversed.
Additionally the labels on the button are reversed too, saying `ON` when it's literally off and the other way around.

# Fix / changes

- Reverse the function calls
- Reverse the labels

# Additional changes

- Change the button's text from `ON` to `Release` and from `OFF` to `Request` because it describes the actions which will be triggered by clicking the button. IMHO that helps understanding the demo more easily. But feel free to keep `ON` and `OFF` that's not important :)

# Misc

* [x] I tested my changes locally 
* [x] Git hooks ran successfully

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

copilot:summary

copilot:walkthrough
