### PR TITLE
docs: Fixed incorrect usage

### DIFF
--- a/packages/core/src/useColorMode/index.md
+++ b/packages/core/src/useColorMode/index.md
@@ -15,7 +15,7 @@ Reactive color mode (dark / light / customs) with auto data persistence.
 ```js
 import { useColorMode } from 'solidjs-use'
 
-const [mode, setMode] = useColorMode() // Signal<'dark' | 'light'>
+const {mode, setMode} = useColorMode() // Signal<'dark' | 'light'>
 ```
 
 By default, it will match with users' browser preference using `usePreferredDark` (a.k.a `auto` mode). When reading the ref, it will by default return the current color mode (`dark`, `light` or your custom modes). The `auto` mode can be included in the returned modes by enabling the `emitAuto` option. When writing to the ref, it will trigger DOM updates and persist the color mode to local storage (or your custom storage). You can pass `auto` to set back to auto mode.
@@ -33,7 +33,7 @@ setMode('auto') // change to auto mode
 ```js
 import { useColorMode } from 'solidjs-use'
 
-const [mode, setMode] = useColorMode({
+const {mode, setMode} = useColorMode({
   attribute: 'theme',
   modes: {
     // custom colors


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Fixed incorrect usage of useColorMode
```
const [mode, setMode] = useColorMode()
```

Before modification:
```
const {mode, setMode = useColorMode()
```

After modification:

---

<!-- These allow GitHub Copilot to provide summary for your PR, do not remove it -->

copilot:summary

copilot:walkthrough
