### PR TITLE
Revert "Don't check for `window` twice in `useDeviceOrientation`"

### DIFF
--- a/packages/core/src/useDeviceOrientation/index.ts
+++ b/packages/core/src/useDeviceOrientation/index.ts
@@ -20,7 +20,7 @@ export function useDeviceOrientation(options: ConfigurableWindow = {}) {
   const [beta, setBeta] = createSignal<number | null>(null)
   const [gamma, setGamma] = createSignal<number | null>(null)
 
-  if (isSupported()) {
+  if (window && isSupported()) {
     useEventListener(window, 'deviceorientation', event => {
       setIsAbsolute(event.absolute)
       setAlpha(event.alpha)


### PR DESCRIPTION
Reverts solidjs-use/solidjs-use#40